### PR TITLE
fixing missing backtick in var desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ The following input variables are optional (have default values):
 Description: A map of objects describing one or more Redis cache access policies.
 - `<map key>` - The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `name` - (Required) - The name string of the Redis Cache Access Policy. Changing this forces a new policy to be created.
-  - `permissions - (Required) - A string describing the permissions to be assigned to this Redis Cache Access Policy. Changing this forces a new policy to be created.
+  - `permissions` - (Required) - A string describing the permissions to be assigned to this Redis Cache Access Policy. Changing this forces a new policy to be created.
 
 Example Input:
 
-````hcl
+```hcl
 cache_access_policies = {
   example_policy = {
     name = "example policy"

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -99,7 +99,7 @@ resource "azurerm_log_analytics_workspace" "this_workspace" {
 module "default" {
   source = "../../"
   # source             = "Azure/avm-res-cache-redis/azurerm"
-  # version            = "0.1.1"
+  # version            = "0.1.2"
 
   enable_telemetry              = var.enable_telemetry
   name                          = module.naming.redis_cache.name_unique

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -93,7 +93,7 @@ resource "azurerm_log_analytics_workspace" "this_workspace" {
 module "default" {
   source = "../../"
   # source             = "Azure/avm-res-cache-redis/azurerm"
-  # version            = "0.1.1"
+  # version            = "0.1.2"
 
   enable_telemetry              = var.enable_telemetry
   name                          = module.naming.redis_cache.name_unique

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.1.1"
+    "module_version": "0.1.2"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "cache_access_policies" {
 A map of objects describing one or more Redis cache access policies.
 - `<map key>` - The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time.
   - `name` - (Required) - The name string of the Redis Cache Access Policy. Changing this forces a new policy to be created.
-  - `permissions - (Required) - A string describing the permissions to be assigned to this Redis Cache Access Policy. Changing this forces a new policy to be created.
+  - `permissions` - (Required) - A string describing the permissions to be assigned to this Redis Cache Access Policy. Changing this forces a new policy to be created.
 
 Example Input:
 


### PR DESCRIPTION
## Description

Corrects missing back tick that was causing documentation to render poorly.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
