### PR TITLE
Set default of zones to "nulll"

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -522,6 +522,6 @@ variable "tenant_settings" {
 
 variable "zones" {
   type        = list(string)
-  default     = ["1", "2", "3"]
+  default     = null
   description = "(Optional) - Specifies a list of Availability Zones in which this Redis Cache should be located.  Changing this forces a new Redis Cache to be created."
 }


### PR DESCRIPTION
## Description

Otherwise, Redis Cache instances with non-premium sku can not be created

With `sku_name  = "Standard"` and `var.zones` not supplied following error prevents creation of ressouces: 
 
 (400 Bad Request) with error: BadRequest: Feature zones requires a Premium sku to be set.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
