### PR TITLE
Fix variable 'cache_access_policy_assignments' example

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ cache_access_policy_assignments = {
     name = "example_assignment"
     access_policy_name = "Data Contributor"
     object_id = data.azurerm_client_config.test.object_id
-    object_policy_alias = "ServicePrincipal"
+    object_id_alias = "ServicePrincipal"
   }
 }
 ```


### PR DESCRIPTION
Fix variable 'cache_access_policy_assignments' example. The var is 'object_id_alias' but was write as 'object_policy_alias' in the provided example.

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
